### PR TITLE
Fix example code and dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Use it:
 ```javascript
 gulp.task('md2json_task', function() {
   return gulp.src('./file.md')
-  .pipe(md2json.parse())
+  .pipe(md2json())
   .pipe(gulp.dest('.'));
 })
 ```

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "license": "ISC",
   "description": "Parse Markdown to JSON.",
-  "devDependencies": {
+  "dependencies": {
       "gulp-util": "^2.2.0",
       "marked": "^0.3.0",
       "through2": "^2.0.1"


### PR DESCRIPTION
Resolve #1 

- Corrected example code so that function is called directly md2json() instead of function  md2json.parse() that doesn't exist
- Moved dependencies from devDependencies to Dependencies to allow for auto install by npm in specified versions